### PR TITLE
Fix backend dev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# CCAMEMFileManager
+
+Para ejecutar el entorno de desarrollo se deben iniciar por separado el
+frontend y el backend.
+
+```bash
+# Iniciar frontend
+cd frontend
+npm run dev
+```
+
+```bash
+# Iniciar backend
+cd backend
+npm run dev
+```
+
+El frontend quedará accesible en `http://localhost:5173` y el backend en
+`http://localhost:3000`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,10 +5,10 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "vite",
+    "dev": "nodemon server.js",
     "build": "vite build",
     "preview": "vite preview",
-    "server": "nodemon server.js",
+    "server": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "test-db": "node test-db.js"
   },


### PR DESCRIPTION
## Summary
- use nodemon for `npm run dev` in backend
- document how to start frontend and backend

## Testing
- `npm --version` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68782733ea6c832ab19290e3901bea9c