### PR TITLE
Fix frontend field names and add services

### DIFF
--- a/frontend/src/pages/Digitalizacion.jsx
+++ b/frontend/src/pages/Digitalizacion.jsx
@@ -80,7 +80,7 @@ const Digitalizacion = () => {
    */
   const cargarExpedientes = async () => {
     try {
-      const response = await axios.get('/expedientes?estatus=ACTIVO&limit=100');
+      const response = await axios.get('/expedientes?estado=activo&limit=100');
       setExpedientes(response.data.expedientes);
     } catch (error) {
       console.error('Error al cargar expedientes:', error);
@@ -356,10 +356,10 @@ const Digitalizacion = () => {
                     <strong>Asunto:</strong> {selectedExpediente.asunto}
                   </Typography>
                   <Typography variant="body2">
-                    <strong>Fojas actuales:</strong> {selectedExpediente.total_fojas}
+                    <strong>Fojas actuales:</strong> {selectedExpediente.total_hojas}
                   </Typography>
                   <Chip
-                    label={selectedExpediente.estatus}
+                    label={selectedExpediente.estado}
                     size="small"
                     color="success"
                     sx={{ mt: 1 }}

--- a/frontend/src/pages/ExpedienteDetail.jsx
+++ b/frontend/src/pages/ExpedienteDetail.jsx
@@ -280,9 +280,9 @@ const ExpedienteDetail = () => {
             </Typography>
           </Grid>
           <Grid item xs={12} md={4} textAlign="right">
-            <Chip 
-              label={expediente.estatus} 
-              color={getStatusColor(expediente.estatus)}
+            <Chip
+              label={expediente.estado?.toUpperCase()}
+              color={getStatusColor(expediente.estado?.toUpperCase())}
               size="large"
             />
           </Grid>
@@ -389,7 +389,7 @@ const ExpedienteDetail = () => {
                     </ListItemIcon>
                     <ListItemText
                       primary="Fojas / Legajos"
-                      secondary={`${expediente.total_fojas} fojas en ${expediente.total_legajos} legajo(s)`}
+                      secondary={`${expediente.total_hojas} fojas en ${expediente.numero_legajos} legajo(s)`}
                     />
                   </ListItem>
                   <ListItem>

--- a/frontend/src/pages/Reportes.jsx
+++ b/frontend/src/pages/Reportes.jsx
@@ -71,7 +71,7 @@ const Reportes = () => {
     area_id: '',
     seccion_id: '',
     serie_id: '',
-    estatus: '',
+    estado: '',
     formato: 'excel'
   });
 
@@ -262,7 +262,7 @@ const Reportes = () => {
         ...(filters.area_id && { area_id: filters.area_id }),
         ...(filters.seccion_id && { seccion_id: filters.seccion_id }),
         ...(filters.serie_id && { serie_id: filters.serie_id }),
-        ...(filters.estatus && { estatus: filters.estatus })
+        ...(filters.estado && { estado: filters.estado })
       };
 
       const response = await axios.get('/reportes/generar', {
@@ -470,8 +470,8 @@ const Reportes = () => {
                   <FormControl fullWidth>
                     <InputLabel>Estado</InputLabel>
                     <Select
-                      value={filters.estatus}
-                      onChange={(e) => handleFilterChange('estatus', e.target.value)}
+                      value={filters.estado}
+                      onChange={(e) => handleFilterChange('estado', e.target.value)}
                       label="Estado"
                     >
                       <MenuItem value="">
@@ -631,12 +631,12 @@ const Reportes = () => {
                         </TableCell>
                         <TableCell>
                           <Chip
-                            label={row.estatus}
+                            label={row.estado}
                             size="small"
-                            color={row.estatus === 'ACTIVO' ? 'success' : 'default'}
+                            color={row.estado === 'ACTIVO' ? 'success' : 'default'}
                           />
                         </TableCell>
-                        <TableCell>{row.total_fojas}</TableCell>
+                        <TableCell>{row.total_hojas}</TableCell>
                       </TableRow>
                     ))}
                   </TableBody>

--- a/frontend/src/pages/SISER.jsx
+++ b/frontend/src/pages/SISER.jsx
@@ -231,8 +231,8 @@ const SISER = () => {
         seccion: row['Sección'] || '',
         serie: row['Serie'] || row['  Serie'] || '',
         nombre: row['Nombre'] || '',
-        total_fojas: parseInt(row['Total de Fojas'] || row['Total de Fojas '] || 0),
-        legajos: parseInt(row['Legajos'] || 1),
+        total_hojas: parseInt(row['Total de Fojas'] || row['Total de Fojas '] || 0),
+        numero_legajos: parseInt(row['Legajos'] || 1),
         fecha_inicio: row['Fecha de inicio'],
         fecha_cierre: row['Fecha de Cierre'],
         subserie: row['Subserie'] || ''

--- a/frontend/src/services/reportes.service.js
+++ b/frontend/src/services/reportes.service.js
@@ -1,0 +1,13 @@
+import api from './api';
+
+class ReportesService {
+  async generarReporte(params = {}, options = {}) {
+    const response = await api.get('/reportes/generar', {
+      params,
+      responseType: options.preview ? 'json' : 'blob'
+    });
+    return response.data;
+  }
+}
+
+export default new ReportesService();

--- a/frontend/src/services/uploads.service.js
+++ b/frontend/src/services/uploads.service.js
@@ -1,0 +1,36 @@
+import api from './api';
+
+class UploadsService {
+  async subirDocumento(expedienteId, file, data = {}) {
+    const formData = new FormData();
+    formData.append('archivo', file);
+    Object.entries(data).forEach(([key, value]) => formData.append(key, value));
+    return api.post(`/uploads/expediente/${expedienteId}/documento`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    });
+  }
+
+  async subirMultiples(expedienteId, files = []) {
+    const formData = new FormData();
+    files.forEach(f => formData.append('archivos', f));
+    return api.post(`/uploads/expediente/${expedienteId}/documentos`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    });
+  }
+
+  async obtenerDocumentos(expedienteId) {
+    const res = await api.get(`/uploads/expediente/${expedienteId}/documentos`);
+    return res.data;
+  }
+
+  async descargarDocumento(id) {
+    const res = await api.get(`/uploads/documento/${id}/descargar`, { responseType: 'blob' });
+    return res.data;
+  }
+
+  async eliminarDocumento(id) {
+    return api.delete(`/uploads/documento/${id}`);
+  }
+}
+
+export default new UploadsService();


### PR DESCRIPTION
## Summary
- align frontend field names with backend schema
- implement missing `reportes` and `uploads` service modules
- adjust Digitalizacion, Reportes, SISER and ExpedienteDetail pages to use correct fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687848f2c4c8832aa9f178bb43d1b960