### PR TITLE
Fix API data handling for catalog pages

### DIFF
--- a/frontend/src/pages/ExpedienteForm.jsx
+++ b/frontend/src/pages/ExpedienteForm.jsx
@@ -69,7 +69,7 @@ const ExpedienteForm = () => {
   const cargarCatalogos = async () => {
     try {
       const response = await api.get('/catalogo/areas');
-      setAreas(response.data || []);
+      setAreas(response.data?.data || []);
     } catch (error) {
       console.error('Error al cargar áreas:', error);
     }
@@ -79,7 +79,7 @@ const ExpedienteForm = () => {
     try {
       setLoading(true);
       const response = await api.get(`/expedientes/${id}`);
-      const data = response.data;
+      const data = response.data?.data;
       setFormData({
         ...data,
         fecha_apertura: data.fecha_apertura ? new Date(data.fecha_apertura) : new Date(),

--- a/frontend/src/pages/ExpedientesList.jsx
+++ b/frontend/src/pages/ExpedientesList.jsx
@@ -61,9 +61,9 @@ const ExpedientesList = () => {
         ...filters,
       };
 
-      const response = await expedientesService.getExpedientes(params);
-      setExpedientes(response.data);
-      setTotalItems(response.pagination.totalItems);
+      const data = await expedientesService.getExpedientes(params);
+      setExpedientes(data.data || []);
+      setTotalItems(data.pagination?.total || 0);
     } catch (error) {
       console.error('Error cargando expedientes:', error);
     } finally {

--- a/frontend/src/pages/catalogo/Areas.jsx
+++ b/frontend/src/pages/catalogo/Areas.jsx
@@ -38,7 +38,7 @@ const Areas = () => {
       setLoading(true);
       setError(null);
       const response = await api.get('/catalogo/areas');
-      setAreas(response.data || []);
+      setAreas(response.data?.data || []);
     } catch (error) {
       console.error('Error al cargar áreas:', error);
       setError('Error al cargar las áreas. Por favor, intente nuevamente.');


### PR DESCRIPTION
## Summary
- parse backend API responses correctly when fetching areas, expediente lists, and single expediente
- adjust pagination handling in ExpedientesList

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d19505df0832abf28d0176297dd4b